### PR TITLE
Changing Heroku settings to not web

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python start.py
+worker: python start.py


### PR DESCRIPTION
Heroku's trying to bind the `python start.py` to a port. Changing the Procfile to tell the dyno to be a worker and not web