### PR TITLE
Disable "started" messages

### DIFF
--- a/reactbot.py
+++ b/reactbot.py
@@ -145,8 +145,7 @@ class ReactBot(Bot):
         return
 
     def on_open(self, ws):
-        response_json = Bot.send_msg(self, "pantherbot-dev", "Bot successfully started")
-        self.check_in_thread_ts = response_json["ts"]
+        return
 
     # message_json Message
     # Sends a message to the same channel that message_json originates from

--- a/start.py
+++ b/start.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
                     if b.WEBSOCKET != None:
                         b.pb_cooldown = True
             if count_interval % 86400 is 0:
-                proactive_bot.send_msg("pantherbot-dev", "Check-in", thread_ts=react_bot.check_in_thread_ts)
                 logger.info("Proactive still alive")
             if count_interval >= 86400:
                 count_interval = 0


### PR DESCRIPTION
As they were getting quite annoying, and with Heroku restarting the service every day, the bot started messages are best left out. 
Edited the response bot and start code to remove the functionality.